### PR TITLE
Optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ To train the model you can use the following script to use the countdown dataset
 python scripts/train.py --base-model=Qwen/Qwen2.5-1.5B --dataset-type=HF --output-dir=./output
 ```
 
-To run a custom training run with a custom data, hyperparameters, etc. you can use a script with flags like the following example.
+To run a custom training run with a custom data, hyperparameters, mixed precision, etc. you can use a script with flags like the following example.
 
 ```
-python scripts/train.py --base-model=Qwen/Qwen2.5-0.5B --dataset-type=JSON --dataset=./data/small-scale/countdown.json --output-dir=./output --num-epochs=1 --batch-size=2 --learning-rate=1e-5 --num-outputs=2 --epsilon=0.1 --beta=0.05 --mu=1
+python scripts/train.py --base-model=Qwen/Qwen2.5-0.5B --dataset-type=JSON --dataset=./data/small-scale/countdown.json --output-dir=./output --num-epochs=1 --batch-size=2 --learning-rate=1e-5 --num-outputs=2 --epsilon=0.1 --beta=0.05 --mu=1 --mixed-precision
 ```
 
 ## Generate Dataset

--- a/dataset/countdown_utils.py
+++ b/dataset/countdown_utils.py
@@ -198,7 +198,7 @@ def compute_metrics(
 
 def batch_compute_metrics(
     outputs: List[List[str]],
-    queries: List[Dict],
+    queries: Dict,
     format_score: float = 0.1,
     full_score: float = 1.0,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -216,13 +216,20 @@ def batch_compute_metrics(
     """
     rewards = []
     accuracies = []
+    # Numbers is a list of tensors each of shape (batchsize), combine them into a single tensor
+    numbers_tensor = torch.stack(queries["numbers"])
 
     for i, output_group in enumerate(outputs):
         group_rewards = []
         group_accuracies = []
 
+        query = {
+            "numbers": numbers_tensor[:, i].tolist(),
+            "target": queries["target"][i],
+        }
+        # TODO: Could revisit for a more efficient implementation
         for output in output_group:
-            metrics = compute_metrics(output, queries[i], format_score, full_score)
+            metrics = compute_metrics(output, query, format_score, full_score)
             group_rewards.append(metrics["reward_score"])
             group_accuracies.append(metrics["accuracy"])
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -76,6 +76,9 @@ def parse_args():
         "--beta", type=float, default=0.05, help="Beta value for the training."
     )
     parser.add_argument("--mu", type=int, default=1, help="Mu value for the training.")
+    parser.add_argument(
+        "--mixed-precision", action="store_true", help="Use mixed precision training."
+    )
     return parser.parse_args()
 
 
@@ -106,6 +109,7 @@ def main():
             "epsilon": args.epsilon,
             "beta": args.beta,
             "mu": args.mu,
+            "mixed_precision": args.mixed_precision,
         },
     )
 
@@ -199,6 +203,7 @@ def main():
                 eps=eps,
                 beta=beta,
                 mu=mu,
+                mixed_precision=args.mixed_precision,
             )
             if batch_iter % EVALUATION_FREQUENCY == 0:
                 logger.info("Batch %d/%d completed.", batch_iter, len(train_dataloader))

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -22,6 +22,8 @@ from dataset.countdown_utils import batch_compute_metrics
 from dataset.countdown_dataloader import *
 
 MODEL_PRECISION = torch.float32
+RANDOM_SEED = 42
+EVALUATION_FREQUENCY = 20
 
 
 # Read arguments
@@ -128,7 +130,7 @@ def main():
     dataset_size = len(dataset)
     test_size = int(0.1 * dataset_size)
     train_size = dataset_size - test_size
-    generator = torch.Generator().manual_seed(42)
+    generator = torch.Generator().manual_seed(RANDOM_SEED)
     dataset, test_dataset = random_split(
         dataset, [train_size, test_size], generator=generator
     )
@@ -184,12 +186,8 @@ def main():
         batch_iter = 0
         for batch in tqdm(train_dataloader, desc="Training"):
             batch_iter += 1
-            # Transform batch numbers and target into list of dictionaries
-            # This is slightly hacky, might look at instead reworking the reward model to deal with tensors
-            prompt_batch, raw_values_batch = process_batch(batch)
             model = grpo_iteration(
-                query_batch_prompts=prompt_batch,
-                query_batch_raw=raw_values_batch,
+                query_batch=batch,
                 policy_model=model,
                 reference_model=model,
                 reward_model=batch_compute_metrics,
@@ -200,20 +198,16 @@ def main():
                 beta=beta,
                 mu=mu,
             )
-            if batch_iter % 10 == 0:
+            if batch_iter % EVALUATION_FREQUENCY == 0:
                 logger.info("Batch %d/%d completed.", batch_iter, len(train_dataloader))
                 logger.info("Evaluating model...")
                 full_rewards, full_accuracies = [], []
                 for test_batch in tqdm(test_dataloader, desc="Evaluating"):
-                    test_batch_prompts, test_batch_raw_values = process_batch(
-                        test_batch
-                    )
                     rewards, accuracies = evaluate_policy(
                         policy_model=model,
                         tokenizer=tokenizer,
                         reward_model=batch_compute_metrics,
-                        test_batch=test_batch_prompts,
-                        test_batch_raw=test_batch_raw_values,
+                        test_batch=test_batch,
                     )
                     full_rewards.append(rewards)
                     full_accuracies.append(accuracies)
@@ -241,17 +235,6 @@ def main():
     logger.info("Model saved to: %s", output_dir)
     wandb.finish()
     logger.info("Training completed successfully.")
-
-
-def process_batch(batch):
-    batch_numbers = list(map(list, zip(*batch["numbers"])))
-    batch_target = batch["target"]
-    prompt_batch = batch["prompt"]
-    raw_values_batch = [
-        {"numbers": numbers, "target": target}
-        for numbers, target in zip(batch_numbers, batch_target)
-    ]
-    return prompt_batch, raw_values_batch
 
 
 if __name__ == "__main__":

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -173,6 +173,9 @@ def main():
     # Set up the optimizer
     learning_rate = args.learning_rate
     optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate)
+    scaler = torch.amp.GradScaler(
+        "cuda", enabled=args.mixed_precision and device == "cuda"
+    )
     logger.info("Optimizer set up with learning rate: %f", learning_rate)
 
     # Load needed arguments
@@ -199,6 +202,7 @@ def main():
                 reward_model=batch_compute_metrics,
                 tokenizer=tokenizer,
                 optimizer=optimizer,
+                scaler=scaler,
                 G=G,
                 eps=eps,
                 beta=beta,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -21,7 +21,8 @@ from grpo import grpo_iteration, evaluate_policy
 from dataset.countdown_utils import batch_compute_metrics
 from dataset.countdown_dataloader import *
 
-MODEL_PRECISION = torch.float32
+POLICY_MODEL_PRECISION = torch.float32
+REF_MODEL_PRECISION = torch.float16
 RANDOM_SEED = 42
 EVALUATION_FREQUENCY = 20
 
@@ -149,7 +150,7 @@ def main():
     model_name = args.base_model
     logger.info("Loading policy model: %s", model_name)
     model = AutoModelForCausalLM.from_pretrained(
-        model_name, torch_dtype=MODEL_PRECISION
+        model_name, torch_dtype=POLICY_MODEL_PRECISION
     )
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     tokenizer.pad_token = tokenizer.eos_token
@@ -158,7 +159,8 @@ def main():
     logger.info("Policy Model loaded successfully.")
     logger.info("Loading reference model: %s", model_name)
     reference_model = AutoModelForCausalLM.from_pretrained(
-        model_name, torch_dtype=MODEL_PRECISION
+        model_name,
+        torch_dtype=REF_MODEL_PRECISION,
     )
     reference_model.eval()
     reference_model.to("cpu")


### PR DESCRIPTION
3 main changes here in the interest of improving memory efficiency:
1. Got rid of the `process_batch` function, rewrote the `batch_compute_metrics` to just be able to use the batch. There might be more room for efficiency in how we calculate rewards but I'm guessing it's not a major drop in efficiency.
2. Bumped the reference model down to a lower precision. (Maybe redundant with the mixed precision stuff?)
3. Added mixed precision that bumps down the precision for forward passes based on this [guide](https://pytorch.org/tutorials/recipes/recipes/amp_recipe.html). This can be toggled on/off with the `--mixed-precision` flag.

Very new to these things so take a look at if it makes sense to you, very open to cha ging thinds 