### PR TITLE
New compute_log_probs Implementation

### DIFF
--- a/grpo.py
+++ b/grpo.py
@@ -341,8 +341,8 @@ def compute_log_probs(
     shift_labels = labels[..., 1:].contiguous()
 
     # Create mask for valid labels
-    label_mask = (shift_labels != -100).float()
-    shift_labels[shift_labels == -100] = 0
+    label_mask = (shift_labels != IGNORE_INDEX).float()
+    shift_labels[shift_labels == IGNORE_INDEX] = 0
 
     # Calculate log probabilities
     log_probs = torch.log_softmax(shift_logits, dim=-1)

--- a/grpo.py
+++ b/grpo.py
@@ -290,6 +290,8 @@ def compute_log_probs(
     """
     The following code closely follows the implementation found at: 
     https://github.com/McGill-NLP/nano-aha-moment/blob/0ce62ece2681eefad8041b9336fc7d2cd1a3687a/utils.py#L109
+
+
     Compute token-level log probabilities for a sequence using the policy model.
 
     This function processes input sequences through the policy model and calculates

--- a/grpo.py
+++ b/grpo.py
@@ -83,7 +83,6 @@ def grpo_iteration(
     # Compute token-level advantage for each token in each output
     advantages = calculate_grpo_advantage(rewards)
     logger.info(f"Advantages: {advantages}")
-    wandb.log(f"Mean Advantages: {advantages.mean()}")
 
     #  Compute log probabilities for reference model and pre-update policy, no gradients here
     with torch.no_grad():

--- a/grpo.py
+++ b/grpo.py
@@ -123,7 +123,7 @@ def grpo_iteration(
             inputs=model_outputs,
             temperature=temperature,
         )
-        
+
         # Compute GRPO objective
         objective = calculate_grpo_objective(
             model_log_probs=model_log_probs,
@@ -424,7 +424,7 @@ def calculate_grpo_objective(
 
     kl_div = kl_div_estimator(model_log_probs, ref_model_log_probs) # (batch_size * G, seq_length-1)
 
-    logger.info(f"Mean KL Div: {torch.mean(kl_div).item()}") 
+    logger.info(f"Mean KL Div: {torch.mean(kl_div).item()}")
     wandb.log({"Mean KL Div": torch.mean(kl_div).item()})
 
     objective = expected_advantage - beta * kl_div 

--- a/grpo.py
+++ b/grpo.py
@@ -470,11 +470,12 @@ def evaluate_policy(
             max_new_tokens=max_new_tokens,
             temperature=temperature,
         )
-        logger.debug(f"Evaluate Outputs: {model_outputs['all_responses']}")
+        all_responses = model_outputs["all_responses"]
+        logger.debug(f"Evaluate Outputs: {all_responses}")
 
     clear_cache()
 
     # Compute rewards and accuracies for each output
-    rewards, accuracies = reward_model(model_outputs['all_responses'], test_batch)
+    rewards, accuracies = reward_model(all_responses, test_batch)
 
     return rewards, accuracies

--- a/grpo.py
+++ b/grpo.py
@@ -96,7 +96,7 @@ def grpo_iteration(
         reference_model.to(gpu_device)
 
         reference_model_log_probs = compute_log_probs(
-            policy=policy_model,
+            policy=reference_model,
             inputs=inputs,  
             temperature=temperature,
         )

--- a/grpo.py
+++ b/grpo.py
@@ -50,7 +50,7 @@ def grpo_iteration(
         The updated policy.
     """
     # Sample G outputs from the policy for each query in query_batch
-    outputs_ids, generated_ids, outputs = sample_outputs(
+    inputs, outputs = sample_outputs(
         policy_model,
         tokenizer,
         query_batch["prompt"],

--- a/grpo.py
+++ b/grpo.py
@@ -301,14 +301,14 @@ def compute_log_probs(
     Args:
         policy: The language model to use for computing log probabilities
         inputs: Dictionary containing:
-            - input_ids: Token IDs tensor of shape [batch_size, seq_len]
-            - attention_mask: Attention mask tensor of shape [batch_size, seq_len]
-            - labels: Target labels tensor of shape [batch_size, seq_len] where
+            - input_ids: Token IDs tensor of shape [batch_size * G, seq_len]
+            - attention_mask: Attention mask tensor of shape [batch_size * G, seq_len]
+            - labels: Target labels tensor of shape [batch_size * G, seq_len] where
               positions to ignore are marked with -100
         temperature: Scaling factor for logits before softmax (default: TEMPERATURE)
 
     Returns:
-        torch.Tensor: Log probabilities tensor of shape [batch_size, seq_len-1]
+        torch.Tensor: Log probabilities tensor of shape [batch_size * G, seq_len-1]
             - Each value represents the log probability of the token that appeared
             - Sequence length is reduced by 1 due to causal modeling requirements
             - Invalid positions (padding/query tokens) have log probability of 0

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -160,7 +160,7 @@ def main():
         torch_dtype=POLICY_MODEL_PRECISION,
     )
     tokenizer = AutoTokenizer.from_pretrained(model_name)
-    tokenizer.pad_token = tokenizer.eos_token
+    # tokenizer.pad_token = tokenizer.eos_token
     tokenizer.padding_side = "left"
     model.to(device)
     logger.info("Policy Model loaded successfully.")

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -160,7 +160,6 @@ def main():
         torch_dtype=POLICY_MODEL_PRECISION,
     )
     tokenizer = AutoTokenizer.from_pretrained(model_name)
-    # tokenizer.pad_token = tokenizer.eos_token
     tokenizer.padding_side = "left"
     model.to(device)
     logger.info("Policy Model loaded successfully.")


### PR DESCRIPTION
This newer compute_log_probs implementation follows the [MILA repo](https://github.com/McGill-NLP/nano-aha-moment/blob/0ce62ece2681eefad8041b9336fc7d2cd1a3687a/utils.py#L109).

## Changes to other functions that will need to be made
@Kuzcop I have updated the function to use a dictionary-based input format like in the MILA repo. This will mean corresponding changes to `sample_outputs` and `grpo_iteration` have to be made.

#### 1. `sample_outputs` Function
- **Current Return Type**: `tuple[torch.Tensor, torch.Tensor, List[List[str]]]`
- **New Return Type**: `tuple[Dict[str, torch.Tensor], List[List[str]]]`
- **Changes Needed**:
  - Instead of returning separate tensors for `output_ids` and `generated_ids`, we can return a dictionary containing:
    ```python
    {
        "input_ids": torch.Tensor,      # Shape: [batch_size * G, seq_len]
        "attention_mask": torch.Tensor, # Shape: [batch_size * G, seq_len]
        "labels": torch.Tensor          # Shape: [batch_size * G, seq_len]
    }
    ```
  - The `labels` tensor should mark query tokens with -100 like the MILA repo
  - We can keep the generated text responses as the second return value

#### 2. `grpo_iteration` Function
- **Changes Needed**:
  - Update the call to `sample_outputs` to handle this new return format
  - We will have to replace direct tensor usage with dictionary access:
    ```python
    # Replace
    padding_mask = generated_ids.ne(tokenizer.pad_token_id)
    
    # With
    padding_mask = inputs["input_ids"].ne(tokenizer.pad_token_id)
    ```
  - Update all calls to `compute_log_probs` to pass the new input format:
    ```python
    # Replace
    old_log_probs = compute_log_probs(
        policy=policy_model,
        tokenizer=tokenizer,
        query_batch=query_batch["prompt"],
        output_ids=outputs_ids,
        generated_ids=generated_ids,
        temperature=temperature,
    )
    
    # With
    old_log_probs = compute_log_probs(
        policy=policy_model,
        inputs=inputs,  # The dictionary from sample_outputs
        temperature=temperature,
    )
    ```