### PR TITLE
New Reward Scores and Micro Batches

### DIFF
--- a/dataset/countdown_utils.py
+++ b/dataset/countdown_utils.py
@@ -101,26 +101,24 @@ def gen_dataset(
 def extract_solution(solution_str: str) -> Optional[str]:
     """
     Extract the final arithmetic equation from the model output.
-    This code closely follows the implementation in TinyZero.
-    https://github.com/Jiayi-Pan/TinyZero/blob/0349609d618d477ed3a9834d56952c7647a50c2d/verl/utils/reward_score/countdown.py#L7
     """
-    # Remove everything before the first "Assistant:"
-    if "Assistant:" in solution_str:
-        solution_str = solution_str.split("Assistant:", 1)[1]
-    elif "<|im_start|>assistant" in solution_str:
-        solution_str = solution_str.split("<|im_start|>assistant", 1)[1]
-    else:
-        return None
-    solution_str = solution_str.split('\n')[-1]
+    eq_pattern = r"([0-9+\-*/\(\)\s]+=[0-9+\-*/\(\)\s]+)"
 
-    answer_pattern = r"<answer>(.*?)</answer>"
-    match = re.finditer(answer_pattern, solution_str)
-    matches = list(match)
-    if matches:
-        final_answer = matches[-1].group(1).strip()
-    else:
-        final_answer = None
-    return final_answer
+    # Find all possible equations
+    matches = re.findall(eq_pattern, solution_str)
+    if not matches:
+        return None
+
+    # Take the last matched equation (in case there's more than one)
+    equation = matches[-1].strip()
+
+    equation = re.sub(r"\\boxed\{(.*?)\}", r"\1", equation)  # remove \boxed{ }
+    equation = re.sub(r"[\[\]]", "", equation)  # remove [ and ]
+
+    # strip newlines or extra spaces
+    equation = " ".join(equation.split())
+
+    return equation if equation else None
 
 
 def validate_equation(equation_str: str, available_numbers: List[int]) -> bool:

--- a/dataset/countdown_utils.py
+++ b/dataset/countdown_utils.py
@@ -157,7 +157,7 @@ def evaluate_equation(equation_str: str) -> Optional[float]:
 
 
 def compute_metrics(
-    output: str, query: Dict, format_score: float = 0.5, equation_score: float = 1.0
+    output: str, query: Dict, format_score: float = 0.5, equation_score: float = 3.0
 ) -> Dict[str, float]:
     """
     Compute four metrics for the countdown solution:
@@ -172,7 +172,7 @@ def compute_metrics(
             - 'target': The target number to reach
             - 'numbers': List of available numbers to use
         format_score: Reward given for correct format but incorrect equation (default: 0.5)
-        equation_score: Reward given for correct equation (default: 1.0)
+        equation_score: Reward given for correct equation (default: 3.0)
 
     Returns:
         Dict[str, float]: Dictionary containing:
@@ -212,7 +212,7 @@ def batch_compute_metrics(
     outputs: List[List[str]],
     queries: Dict,
     format_score: float = 0.5,
-    equation_score: float = 1.0,
+    equation_score: float = 3.0,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Batch process the outputs and queries to compute rewards and accuracies.
@@ -224,7 +224,7 @@ def batch_compute_metrics(
             - 'target': Tensor of target numbers, shape (batch_size,)
             - 'numbers': List of tensors of available numbers, each shape (batch_size,)
         format_score: Reward for correct format but incorrect equation (default: 0.5)
-        equation_score: Reward for correct equation (default: 1.0)
+        equation_score: Reward for correct equation (default: 3.0)
 
     Returns:
         Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]: Four tensors of shape (batch_size, G):

--- a/environment.yml
+++ b/environment.yml
@@ -83,7 +83,7 @@ dependencies:
   - libcblas=3.9.0
   - libcrc32c=1.1.2
   - libcurl=8.13.0
-  - libcxx=20.1.2
+#  - libcxx=20.1.2
   - libedit=3.1.20250104
   - libev=4.33
   - libevent=2.1.12

--- a/grpo.py
+++ b/grpo.py
@@ -11,7 +11,7 @@ import gc
 SampleDict = Dict[str, Union[torch.Tensor, List[List[str]]]]
 
 # Global constants
-MAX_NEW_TOKENS = 1024
+MAX_NEW_TOKENS = 768
 TEMPERATURE = 1.0
 STABILITY_CONST = 1e-4
 GRAD_CLIPPING_NORM = 10.0

--- a/grpo.py
+++ b/grpo.py
@@ -11,7 +11,7 @@ import gc
 SampleDict = Dict[str, Union[torch.Tensor, List[List[str]]]]
 
 # Global constants
-MAX_NEW_TOKENS = 768
+MAX_NEW_TOKENS = 1024
 TEMPERATURE = 1.0
 STABILITY_CONST = 1e-4
 GRAD_CLIPPING_NORM = 10.0

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -240,6 +240,7 @@ def main():
                     optimizer.zero_grad()
                     step_count += 1
                     logger.info("Step %d completed.", step_count)
+                    logger.info("Train loss: %f", total_loss / grad_accum_steps)
                     wandb.log({"train_loss": total_loss / grad_accum_steps, "step": step_count})
                     total_loss = 0
                 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -209,26 +209,34 @@ def main():
             if batch_iter % EVALUATION_FREQUENCY == 0:
                 logger.info("Batch %d/%d completed.", batch_iter, len(train_dataloader))
                 logger.info("Evaluating model...")
-                full_rewards, full_accuracies = [], []
+                full_format_rewards, full_equation_rewards, full_total_rewards, full_accuracies = [], [], [], []
                 for test_batch in tqdm(test_dataloader, desc="Evaluating"):
-                    rewards, accuracies = evaluate_policy(
+                    format_rewards, equation_rewards, total_rewards, accuracies = evaluate_policy(
                         policy_model=model,
                         tokenizer=tokenizer,
                         reward_model=batch_compute_metrics,
                         test_batch=test_batch,
                     )
-                    full_rewards.append(rewards)
+                    full_format_rewards.append(format_rewards)
+                    full_equation_rewards.append(equation_rewards)
+                    full_total_rewards.append(total_rewards)
                     full_accuracies.append(accuracies)
-                full_rewards = torch.cat(full_rewards)
+                full_format_rewards = torch.cat(full_format_rewards)
+                full_equation_rewards = torch.cat(full_equation_rewards)
+                full_total_rewards = torch.cat(full_total_rewards)
                 full_accuracies = torch.cat(full_accuracies)
                 logger.info("Evaluation completed.")
-                logger.info("Mean reward: %f", full_rewards.mean().item())
+                logger.info("Mean format reward: %f", full_format_rewards.mean().item())
+                logger.info("Mean equation reward: %f", full_equation_rewards.mean().item())
+                logger.info("Mean total reward: %f", full_total_rewards.mean().item())
                 logger.info("Mean accuracy: %f", full_accuracies.mean().item())
                 wandb.log(
                     {
                         "epoch": epoch + 1,
                         "batch": batch_iter,
-                        "test_mean_reward": full_rewards.mean().item(),
+                        "test_mean_format_reward": full_format_rewards.mean().item(),
+                        "test_mean_equation_reward": full_equation_rewards.mean().item(),
+                        "test_mean_total_reward": full_total_rewards.mean().item(),
                         "test_mean_accuracy": full_accuracies.mean().item(),
                     }
                 )


### PR DESCRIPTION
This PR introduces **gradient accumulation using micro-batching** to the `grpo_iteration` training loop as well as a new reward function.

### 1. Gradient Accumulation Support
- `grpo_iteration()` now accepts a new `accumulate: bool` flag.
- When `accumulate=True`, it returns the **scalar loss** instead of performing `optimizer.step()`, allowing the main loop to manage accumulation and stepping.

### 2. Micro-Batching in Training Loop
- `train.py` has been modified to:
  - Slice large batches into micro-batches.
  - Accumulate gradients over `grad_accum_steps` before stepping the optimizer.
  - Reset gradients only after accumulation.

### 3. When running the script
New arguments:
- `--micro-batch-size`: Prompts processed per forward/backward pass (default: `2`)
- `--grad-accum-steps`: Number of micro-batches to accumulate before optimizer step (default: `4`)

### 4. Reward Score
- **Format Reward**: `0.5` if the format is correct, `0.0` otherwise.
-  **Equation Reward**: `3.0` if the equation is correct, `0.0` otherwise.
-  **Total Reward**: `Format + Equation` (i.e., ranges from `0.0` to `3.5`).
- **Accuracy**: Remains a binary `0` or `1` indicator based on full correctness.
